### PR TITLE
Generalize to allow color from image formats other than PNG

### DIFF
--- a/gui/tools/ReconstructionData.cxx
+++ b/gui/tools/ReconstructionData.cxx
@@ -36,6 +36,8 @@
 // VTK includes
 #include "vtkDoubleArray.h"
 #include "vtkImageData.h"
+#include "vtkImageReader2Factory.h"
+#include "vtkImageReader2.h"
 #include "vtkVector.h"
 #include "vtkMatrix3x3.h"
 #include "vtkMatrix4x4.h"
@@ -43,7 +45,6 @@
 #include "vtkSmartPointer.h"
 #include "vtkTransform.h"
 #include "vtkUnsignedCharArray.h"
-#include "vtkPNGReader.h"
 
 
 ReconstructionData::ReconstructionData()
@@ -93,7 +94,7 @@ ReconstructionData::~ReconstructionData()
 void ReconstructionData::GetColorValue(int* pixelPosition, double rgb[3])
 {
   vtkUnsignedCharArray* color =
-    vtkUnsignedCharArray::SafeDownCast(this->DepthMap->GetPointData()->GetArray("PNGImage"));
+    vtkUnsignedCharArray::SafeDownCast(this->DepthMap->GetPointData()->GetArray(0));
 
   if (color == 0)
     {
@@ -237,8 +238,10 @@ void ReconstructionData::SetMatrixRT(vtkMatrix4x4* matrix)
 
 void ReconstructionData::ReadDepthMap(std::string path, vtkImageData* out)
 {
-  vtkSmartPointer<vtkPNGReader> depthMapReader = vtkSmartPointer<vtkPNGReader>::New();
-  depthMapReader->SetFileName(path.c_str());
-  depthMapReader->Update();
-  out->ShallowCopy(depthMapReader->GetOutput());
+  vtkSmartPointer<vtkImageReader2Factory> readerFactory =
+      vtkSmartPointer<vtkImageReader2Factory>::New();
+  vtkSmartPointer<vtkImageReader2> imageReader = readerFactory->CreateImageReader2(path.c_str());
+  imageReader->SetFileName(path.c_str());
+  imageReader->Update();
+  out->ShallowCopy(imageReader->GetOutput());
 }


### PR DESCRIPTION
This is a workaround allowing the mesh coloration algorithm to load images from formats other than PNG.  It uses a factory to figure out which image reader to use from those supported by VTK.  This allows, for example, JPEG images to be used.

Longer term this code still needs more refactoring and clean-up before landing in master.  This code seems to be written to load depth maps but is actually being used to load color images.  It would be preferable for the algorithms to request camera and image data from the application itself instead of reloading from files.  In the future we may support data, like video, that does not have image files on disk.  The algorithm should be able to run on any data that they application is able to load.